### PR TITLE
Added support for 3D SpacePilot Pro

### DIFF
--- a/helper/80-hid-g19.rules
+++ b/helper/80-hid-g19.rules
@@ -1,3 +1,4 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c229", GROUP="input", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c228", GROUP="input", MODE="0660"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c629", GROUP="input", MODE="0660"
 

--- a/src/80-hid-g19.rules
+++ b/src/80-hid-g19.rules
@@ -1,3 +1,4 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c229", GROUP="input", MODE="0660"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c228", GROUP="input", MODE="0660"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="046d", ATTRS{idProduct}=="c629", GROUP="input", MODE="0660"
 

--- a/src/g19daemon.cpp
+++ b/src/g19daemon.cpp
@@ -48,8 +48,7 @@ G19daemon::G19daemon(QWidget *parent)
     qRegisterMetaType<gAction>("gAction");
 
     device = new G19Device;
-    device->initializeDevice();
-    device->openDevice();
+    device->initialize();
 
     settings = new QSettings("G19Daemon", "G19Daemon");
 
@@ -115,7 +114,7 @@ G19daemon::~G19daemon() {
 
     delete settings;
 
-    device->closeDevice();
+    device->uninitialize();
     delete device;
 }
 

--- a/src/g19device.hpp
+++ b/src/g19device.hpp
@@ -85,10 +85,13 @@ public:
   G19Device();
   ~G19Device();
 
-  void initializeDevice();
-  void openDevice();
+  void initialize();
+  void uninitialize();
+  void openDevice(libusb_device_handle* device);
   void closeDevice();
   void eventThread();
+  bool probeDevice(libusb_device *device);
+  bool isDevice(libusb_device *device);
 
   void updateLcd(QImage *img);
   void setKeysBacklight(QColor color);
@@ -127,8 +130,7 @@ private:
   libusb_context *context;
   libusb_device_handle *deviceHandle;
   libusb_device_descriptor deviceDesc;
-
-  bool probeDevice(libusb_device *device);
+  libusb_hotplug_callback_handle hotplugCallback;
   bool probeDevices();
 
   QFuture<void> future;

--- a/src/g19device.hpp
+++ b/src/g19device.hpp
@@ -62,6 +62,19 @@ enum G19Keys {
   G19_KEY_LIGHT = 1 << 24
 };
 
+#define G19_HAS_G_KEYS (1 << 0)
+#define G19_HAS_M_KEYS (1 << 1)
+#define G19_HAS_BACKLIGHT_CONTROL (1 << 2)
+#define G19_HAS_BRIGHTNESS_CONTROL (1 << 3)
+
+
+typedef struct  {
+  uint16_t vid;
+  uint16_t pid;
+  int flags;
+  int interface;
+} G19DeviceType;
+
 typedef void (*G19KeysCallback)(unsigned int keys);
 
 class G19Device : public QObject {
@@ -93,6 +106,8 @@ public:
   bool gKeysTransferCancelled;
   bool lKeysTransferCancelled;
 
+  G19DeviceType type;
+
 private:
   unsigned int lastkeys;
   bool isDeviceConnected;
@@ -112,9 +127,9 @@ private:
   libusb_context *context;
   libusb_device_handle *deviceHandle;
   libusb_device_descriptor deviceDesc;
-  libusb_device **devs;
-  libusb_device *dev;
-  //		int usbInterfaceNumber;
+
+  bool probeDevice(libusb_device *device);
+  bool probeDevices();
 
   QFuture<void> future;
 


### PR DESCRIPTION
This adds support for the 3Dconnexion SpacePilot Pro.  It's essentially a 3D CAD controller with a G19 display attached.  Please test with an actual G19 keyboard, as I _may_ have broken something by switching from libusb_set_auto_detach_kernel_driver() to explicitly detaching and attaching only on the proper interface (in the case of the SpacePilot Pro, that's interface 0 -- it appears to be interface 1 on the G19?).  This was necessary because it was detaching from _both_ interfaces and breaking the 3D mouse interface.  

In addition I notice the sample udev rules file was looking for both 046d:c228 and 046d:c229, but the code was _explicitly_ only attaching to c229.  I assume there is some other keyboard that's 046d:c228 -- if that is the case, the new G19DeviceType array ought to be updated with that too.

The structure here kind of precludes multiple G19-style devices, or multiple instances of g19daemon, but this was the quickest way to add 'out-of-the-box' support for a new single device.  
