### PR TITLE
Fix G19 macro key handling on newer Linux systems

### DIFF
--- a/src/g19device.cpp
+++ b/src/g19device.cpp
@@ -62,14 +62,20 @@ extern "C" void LIBUSB_CALL GKeysCallback(libusb_transfer *transfer) {
     }
 
     if (status == LIBUSB_TRANSFER_COMPLETED) {
-        if (transfer->length < 3)
+        if (transfer->actual_length < 3) {
+            libusb_submit_transfer(transfer);
             return;
+        }
 
-        if (transfer->buffer[0] < 1)
+        if (transfer->buffer[0] != 0x02) {
+            libusb_submit_transfer(transfer);
             return;
+        }
 
-        if ((transfer->buffer[1] & 0x00) && (transfer->buffer[2] & 0x00))
+        if ((transfer->buffer[1] == 0x00) && (transfer->buffer[2] == 0x00)) {
+            cthis->gKeyCallback(0);
             return;
+        }
 
         if (transfer->buffer[1] & 0x01)
             keys |= G19_KEY_G1;
@@ -281,8 +287,8 @@ void G19Device::openDevice(libusb_device_handle *handle) {
         if (type.flags.contains(G19_HAS_G_KEYS)) {
             gKeysTransfer = libusb_alloc_transfer(0);
             libusb_fill_interrupt_transfer(gKeysTransfer, handle,
-                                           LIBUSB_ENDPOINT_IN | LIBUSB_RECIPIENT_OTHER,
-                                           gKeysBuffer, 4, GKeysCallback, this, 0);
+                                           0x83,
+                                           gKeysBuffer, 7, GKeysCallback, this, 0);
             libusb_submit_transfer(gKeysTransfer);
         }
 

--- a/src/g19device.hpp
+++ b/src/g19device.hpp
@@ -144,7 +144,7 @@ private:
     libusb_transfer *lKeysTransfer;
     libusb_transfer *dataTransfer{};
 
-    unsigned char gKeysBuffer[4]{};
+    unsigned char gKeysBuffer[7]{};
     unsigned char lKeysBuffer[2]{};
 
     libusb_context *context;


### PR DESCRIPTION
## Problem

On Linux Mint 22 (Ubuntu 24.04 based), Logitech G19 macro keys only worked once after starting g19daemon.

The first key press was detected correctly, but subsequent G-key presses were ignored until the daemon was restarted.

## Root Cause

The G19 macro interface (046d:c229) exposes endpoint 0x83 and produces additional 7-byte reports besides the actual macro key reports.

The current implementation uses a 4-byte buffer and does not correctly handle these additional reports.

## Changes

* Increase gKeysBuffer from 4 to 7 bytes.
* Use endpoint 0x83 explicitly for the macro interface.
* Ignore non-macro reports (`buffer[0] != 0x02`).
* Re-submit transfers after ignored reports.
* Properly handle key release events.

## Testing

Tested on:

* Linux Mint 22.3 (Zena)
* Logitech G19 (046d:c229)

Verified:

* G1-G12 work repeatedly.
* M1/M2/M3 profiles work correctly.
* Multiple consecutive key presses are detected reliably.
* Commands assigned to G-keys can be executed repeatedly without restarting the daemon.

## Related

This appears to resolve the behavior originally reported in issue #33.
